### PR TITLE
Href Issue for Footer hyperlink (Join IEEE)

### DIFF
--- a/src/components/Common/Footer/index.js
+++ b/src/components/Common/Footer/index.js
@@ -30,7 +30,7 @@ const FooterComponent = () => {
               <ListGroup.Item
                 className="p-0 px-3 border-0  bg-transparent text text-white"
                 action
-                href="/home"
+                href="/membership"
               >
                 Join IEEE
               </ListGroup.Item>


### PR DESCRIPTION
A Hyperlink present in the Footer of App, called "Join IEEE", had wrong href value.
Changed from "/home" to "/membership".